### PR TITLE
Add a lib directory with built JS files to publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/lib/
 /node_modules/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "core-decorators",
   "version": "0.0.13",
   "description": "Library of ES7 decorators inspired by languages that come with built-ins like @override, @deprecated, etc",
-  "main": "src/core-decorators.js",
+  "main": "lib/core-decorators.js",
+  "files": ["lib"],
   "scripts": {
-    "test": "mocha --require babel/register 'src/**/*.spec.js'"
+    "build": "babel --stage 0 --out-dir lib src",
+    "test": "mocha --require babel/polyfill 'lib/**/*.spec.js'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds ES5 output since no mainstream JS engine supports ES7 stage 0 code that parts of core-decorators uses. Without this, everyone who wants to use this project via npm needs to transform node_modules themselves which is generally an uncommon thing to do.