### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A version compiled to ES5 in CJS format is published to npm as [`core-decorators
 npm install core-decorators --save
 ```
 
-This form could be consumed by any ES2016 (ES7) transpiler that supports decorators like [babel.js](https://babeljs.io/) with `babel --optional es7.decorators --optional es7.objectRestSpread` or `babel --stage 1` or using the recent iterations of TypeScript.
+This form could be consumed by any ES2016 (ES7) transpiler that supports decorators like [babel.js](https://babeljs.io/) with `babel --optional es7.decorators,es7.objectRestSpread` or `babel --stage 1` or using the recent iterations of TypeScript.
 
 _*note that the compiled code is intentionally not checked into this repo_
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A version compiled to ES5 in CJS format is published to npm as [`core-decorators
 npm install core-decorators --save
 ```
 
-This form could be consumed by any ES2016 (ES7) transpiler that supports decorators like [babel.js](https://babeljs.io/) with `babel --optional es7.decorators` or using the recent iterations of TypeScript.
+This form could be consumed by any ES2016 (ES7) transpiler that supports decorators like [babel.js](https://babeljs.io/) with `babel --optional es7.decorators --optional es7.objectRestSpread` or `babel --stage 1` or using the recent iterations of TypeScript.
 
 _*note that the compiled code is intentionally not checked into this repo_
 

--- a/src/suppress-warnings.js
+++ b/src/suppress-warnings.js
@@ -1,3 +1,5 @@
+import { decorate } from './private/utils';
+
 function suppressedWarningNoop() {
   // Warnings are currently suppressed via @suppressWarnings
 }


### PR DESCRIPTION
Include `--optional es7.objectRestSpread` in the README file instructions since it is needed for example in `supress-warnings.js` line 15