### PR TITLE
fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Creates a new debounced function which will be invoked after `wait` milliseconds
 Optional boolean second argument allows to trigger function on the leading instead of the trailing edge of the wait interval. Implementation is insired by similar method from [UnderscoreJS](http://underscorejs.org/#debounce).
 
 ```js
-import { deprecate } from 'core-decorators';
+import { debounce } from 'core-decorators';
 
 class Editor {
   


### PR DESCRIPTION
Thanks for the new `debounce` decorator. I found a typo in `README.md` and I fixed it in this PR.