### PR TITLE
added lazyInitialize decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,22 @@ This can be consumed by any transpiler that supports decorators like [babel.js](
 ## Decorators
 
 ##### For Properties and Methods
-* [@autobind](#autobind)
 * [@readonly](#readonly)
-* [@override](#override)
-* [@deprecate](#deprecate-alias-deprecated)
-* [@debounce](#debounce)
-* [@throttle](#throttle) :new:
-* [@suppressWarnings](#suppresswarnings)
-* [@enumerable](#enumerable) :new:
-* [@nonenumerable](#nonenumerable)
 * [@nonconfigurable](#nonconfigurable)
 * [@decorate](#decorate) :new:
+
+##### For Properties only
+* [@nonenumerable](#nonenumerable)
+* [@lazyInitialize](#lazyInitialize) :new:
+
+##### For Methods only
+* [@autobind](#autobind)
+* [@deprecate](#deprecate-alias-deprecated)
+* [@suppressWarnings](#suppresswarnings)
+* [@enumerable](#enumerable) :new:
+* [@override](#override)
+* [@debounce](#debounce)
+* [@throttle](#throttle) :new:
 
 ##### For Classes
 * [@mixin](#mixin-alias-mixins) :new:
@@ -261,7 +266,7 @@ Object.keys(dinner);
 
 ### @nonconfigurable
 
-Marks a property or method as not being writable.
+Marks a property or method so that it cannot be reconfigured, changed, or deleted.
 
 ```js
 import { nonconfigurable } from 'core-decorators';
@@ -307,6 +312,34 @@ task.doSomethingExpensive(data);
 
 count === 1;
 // true
+```
+
+### @lazyInitialize
+
+Prevents a property initializer from running until the decorated property is actually looked up. Useful to prevent excess allocations that might otherwise not be used, but be careful not to over-optimize things.
+
+```js
+import { lazyInitialize } from 'core-decorators';
+
+function createHugeBuffer() {
+  console.log('huge buffer created');
+  return new Array(1000000);
+}
+
+class Editor {
+  @lazyInitialize
+  hugeBuffer = createHugeBuffer();
+}
+
+var editor = new Editor();
+// createHugeBuffer() has not been called yet
+
+editor.hugeBuffer;
+// logs 'huge buffer created', now it has been called
+
+editor.hugeBuffer;
+// already initialized and equals our buffer, so
+// createHugeBuffer() is not called again
 ```
 
 ### @mixin (alias: @mixins)

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,6 +1,7 @@
 {
   "optional": [
     "es7.objectRestSpread",
-    "es7.classProperties"
+    "es7.classProperties",
+    "es7.decorators"
   ]
 }

--- a/src/core-decorators.js
+++ b/src/core-decorators.js
@@ -11,3 +11,4 @@ export { default as debounce } from './debounce';
 export { default as throttle } from './throttle';
 export { default as decorate } from './decorate';
 export { default as mixin, default as mixins } from './mixin';
+export { default as lazyInitialize } from './lazy-initialize';

--- a/src/lazy-initialize.js
+++ b/src/lazy-initialize.js
@@ -1,0 +1,34 @@
+import { decorate, createDefaultSetter } from './private/utils';
+
+function handleDescriptor(target, key, descriptor) {
+  const { configurable, enumerable, initializer, value } = descriptor;
+  return {
+    configurable,
+    enumerable,
+
+    get() {
+      // This happens if someone accesses the
+      // property directly on the prototype
+      if (this === target) {
+        return;
+      }
+
+      const ret = initializer ? initializer.call(this) : value;
+
+      Object.defineProperty(this, key, {
+        configurable,
+        enumerable,
+        writable: true,
+        value: ret
+      });
+
+      return ret;
+    },
+
+    set: createDefaultSetter(key)
+  };
+}
+
+export default function lazyInitialize(...args) {
+  return decorate(handleDescriptor, args);
+}

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -1,3 +1,5 @@
+import lazyInitialize from '../lazy-initialize';
+
 const { defineProperty, getOwnPropertyDescriptor,
         getOwnPropertyNames, getOwnPropertySymbols } = Object;
 
@@ -28,8 +30,11 @@ export function decorate(handleDescriptor, entryArgs) {
 }
 
 class Meta {
+  @lazyInitialize
   debounceTimeoutIds = {};
+  @lazyInitialize
   throttleTimeoutIds = {};
+  @lazyInitialize
   throttlePreviousTimestamps = {};
 }
 

--- a/src/suppress-warnings.js
+++ b/src/suppress-warnings.js
@@ -12,7 +12,7 @@ function applyWithoutWarnings(context, fn, args) {
   return ret;
 }
 
-function handleDescriptor(target, key, descriptor, warningTypes) {
+function handleDescriptor(target, key, descriptor) {
   return {
     ...descriptor,
     value: function suppressWarningsWrapper() {

--- a/test/unit/lazy-initialize.spec.js
+++ b/test/unit/lazy-initialize.spec.js
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import lazyInitialize from '../../lib/lazy-initialize';
+
+describe('@lazyInitialize', function () {
+  let initializer;
+
+  class Foo {
+    @lazyInitialize
+    bar = initializer();
+  }
+
+  beforeEach(function () {
+    initializer = spy(() => 'test');
+  });
+
+  afterEach(function () {
+    initializer = null;
+  });
+
+  it('does not initialize property until it the getter is called', function () {
+    const foo = new Foo();
+    initializer.should.not.have.been.called;
+    foo.bar.should.equal('test');
+    foo.bar.should.equal('test');
+    initializer.should.have.been.called.once;
+  });
+
+  it('allows normal reassignment', function () {
+    const foo = new Foo();
+    foo.bar = 'test';
+    initializer.should.not.have.been.called;
+    foo.bar.should.equal('test');
+  });
+
+  it('does not initialize property when looked up on the prototype directly', function () {
+    const value = Foo.prototype.bar;
+    initializer.should.not.have.been.called;
+    expect(value).to.be.undefined;
+  });
+});


### PR DESCRIPTION
### @lazyInitialize

Prevents a property initializer from running until the decorated property is actually looked up. Useful to prevent excess allocations that might otherwise not be used, but be careful not to over-optimize things.

```js
import { lazyInitialize } from 'core-decorators';

function createHugeBuffer() {
  console.log('huge buffer created');
  return new Array(1000000);
}

class Editor {
  @lazyInitialize
  hugeBuffer = createHugeBuffer();
}

var editor = new Editor();
// createHugeBuffer() has not been called yet

editor.hugeBuffer;
// logs 'huge buffer created', now it has been called

editor.hugeBuffer;
// already initialized and equals our buffer, so
// createHugeBuffer() is not called again
```
