### PR TITLE
Added @instrument decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This can be consumed by any transpiler that supports decorators like [babel.js](
 * [@override](#override)
 * [@debounce](#debounce)
 * [@throttle](#throttle) :new:
+* [@instrument](#instrument) :new:
 
 ##### For Classes
 * [@mixin](#mixin-alias-mixins) :new:
 
 
 ##### Proposed (not implemented, PRs welcome!):
-* @instrument/profile
 * @assertArguments(arg1 => arg1, arg2 => arg2)
 * @private
 
@@ -226,7 +226,7 @@ import { enumerable } from 'core-decorators';
 
 class Meal {
   pay() {}
-  
+
   @enumerable
   eat() {}
 }
@@ -374,6 +374,16 @@ bird.singMatingCall();
 // alerts "tweet tweet"
 
 ```
+
+### @instrument
+
+Uses `console.time` and `console.timeEnd` to provide function timings with a unique label whose default prefix is `ClassName.method`.
+
+Will polyfill `console.time` if the current environment does not support it. You can also supply a custom `console` object with the following methods:
+
+* `myConsole.time(label)`
+* `myConsole.timeEnd(label)`
+* `myConsole.log(value)`
 
 # Future Compatibility
 Since most people can't keep up to date with specs, it's important to note that ES2016 (including the decorators spec this relies on) is in-flux and subject to breaking changes. In fact, the [biggest change is coming shortly](https://github.com/wycats/javascript-decorators/pull/36) but I am active in the appropriate communities and will be keeping this project up to date as things progress. For the most part, these changes will usually be transparent to consumers of this project--that said, core-decorators has not yet reached 1.0 and may in fact introduce breaking changes. If you'd prefer not to receive these changes, be sure to lock your dependency to [PATCH](http://semver.org/). You can track the progress of core-decorators@1.0.0 in the [The Road to 1.0](https://github.com/jayphelps/core-decorators.js/issues/15) ticket.

--- a/README.md
+++ b/README.md
@@ -377,13 +377,33 @@ bird.singMatingCall();
 
 ### @instrument
 
-Uses `console.time` and `console.timeEnd` to provide function timings with a unique label whose default prefix is `ClassName.method`.
+Uses `console.time` and `console.timeEnd` to provide function timings with a unique label whose default prefix is `ClassName.method`.  Supply a first argument to override the prefix:
 
-Will polyfill `console.time` if the current environment does not support it. You can also supply a custom `console` object with the following methods:
+```js
+class Bird {
+  @instrument('sing')
+  sing() {
+  }
+}
+
+var bird = new Bird();
+bird.sing(); // console.time label will be 'sing-0'
+bird.sing(); // console.time label will be 'sing-1'
+```
+
+Will polyfill `console.time` if the current environment does not support it. You can also supply a custom `console` object as the second argument with the following methods:
 
 * `myConsole.time(label)`
 * `myConsole.timeEnd(label)`
 * `myConsole.log(value)`
+
+```js
+let myConsole = {
+  time: function(label) { /* custom time() method */ },
+  timeEnd: function(label) { /* custom timeEnd method */ },
+  log: function(str) { /* custom log method */ }
+}
+```
 
 # Future Compatibility
 Since most people can't keep up to date with specs, it's important to note that ES2016 (including the decorators spec this relies on) is in-flux and subject to breaking changes. In fact, the [biggest change is coming shortly](https://github.com/wycats/javascript-decorators/pull/36) but I am active in the appropriate communities and will be keeping this project up to date as things progress. For the most part, these changes will usually be transparent to consumers of this project--that said, core-decorators has not yet reached 1.0 and may in fact introduce breaking changes. If you'd prefer not to receive these changes, be sure to lock your dependency to [PATCH](http://semver.org/). You can track the progress of core-decorators@1.0.0 in the [The Road to 1.0](https://github.com/jayphelps/core-decorators.js/issues/15) ticket.

--- a/src/core-decorators.js
+++ b/src/core-decorators.js
@@ -12,3 +12,4 @@ export { default as throttle } from './throttle';
 export { default as decorate } from './decorate';
 export { default as mixin, default as mixins } from './mixin';
 export { default as lazyInitialize } from './lazy-initialize';
+export { default as instrument } from './instrument';

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -2,6 +2,16 @@ import { decorate } from './private/utils';
 
 const CONSOLE_NATIVE = console;
 
+let labels = {};
+const CONSOLE_TIME = console.time ? console.time.bind(console) : function(label) {
+  labels[label] = new Date();
+};
+const CONSOLE_TIMEEND = console.timeEnd ? console.timeEnd.bind(console) : function(label) {
+  let timeNow = new Date();
+  let timeTaken = timeNow - labels[label];
+  console.log(`${label}: ${timeTaken}ms`);
+};
+
 let count = 0;
 
 function handleDescriptor(target, key, descriptor, [prefix = null, konsole = null]) {
@@ -20,16 +30,8 @@ function handleDescriptor(target, key, descriptor, [prefix = null, konsole = nul
   return {
     ...descriptor,
     value() {
-      let timeStarted;
-      let log = CONSOLE.log ? CONSOLE.log.bind(CONSOLE) : CONSOLE_NATIVE.log.bind(CONSOLE_NATIVE);
-      let time = CONSOLE.time ? CONSOLE.time.bind(CONSOLE) : function() {
-        timeStarted = new Date();
-      };
-      let timeEnd = CONSOLE.timeEnd ? CONSOLE.timeEnd.bind(CONSOLE) : function() {
-        let timeEnded = new Date();
-        let timeTaken = timeEnded - timeStarted;
-        log(`${label}: ${timeTaken}ms`);
-      };
+      let time = CONSOLE.time || CONSOLE_TIME;
+      let timeEnd = CONSOLE.timeEnd || CONSOLE_TIMEEND;
       let label = `${prefix}-${count}`;
       count++;
       time(label);

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -4,10 +4,10 @@ const CONSOLE_NATIVE = console;
 
 let count = 0;
 
-function handleDescriptor(target, key, descriptor, [prefix = null, options = {}]) {
+function handleDescriptor(target, key, descriptor, [prefix = null, konsole = null]) {
   let className = target.constructor.name;
   let fn = descriptor.value;
-  const CONSOLE = options.console || CONSOLE_NATIVE;
+  const CONSOLE = konsole || CONSOLE_NATIVE;
 
   if ( prefix === null ) {
     prefix = `${className}.${key}`;

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -33,8 +33,9 @@ function handleDescriptor(target, key, descriptor, [prefix = null, konsole = nul
       let label = `${prefix}-${count}`;
       count++;
       time(label);
-      fn.apply(this, arguments);
+      let result = fn.apply(this, arguments);
       timeEnd(label);
+      return result;
     }
   }
 }

--- a/src/instrument.js
+++ b/src/instrument.js
@@ -1,0 +1,44 @@
+import { decorate } from './private/utils';
+
+const CONSOLE_NATIVE = console;
+
+let count = 0;
+
+function handleDescriptor(target, key, descriptor, [prefix = null, options = {}]) {
+  let className = target.constructor.name;
+  let fn = descriptor.value;
+  const CONSOLE = options.console || CONSOLE_NATIVE;
+
+  if ( prefix === null ) {
+    prefix = `${className}.${key}`;
+  }
+
+  if (typeof fn !== 'function') {
+    throw new SyntaxError(`@instrument can only be used on functions, not: ${fn}`);
+  }
+
+  return {
+    ...descriptor,
+    value() {
+      let timeStarted;
+      let log = CONSOLE.log ? CONSOLE.log.bind(CONSOLE) : CONSOLE_NATIVE.log.bind(CONSOLE_NATIVE);
+      let time = CONSOLE.time ? CONSOLE.time.bind(CONSOLE) : function() {
+        timeStarted = new Date();
+      };
+      let timeEnd = CONSOLE.timeEnd ? CONSOLE.timeEnd.bind(CONSOLE) : function() {
+        let timeEnded = new Date();
+        let timeTaken = timeEnded - timeStarted;
+        log(`${label}: ${timeTaken}ms`);
+      };
+      let label = `${prefix}-${count}`;
+      count++;
+      time(label);
+      fn.apply(this, arguments);
+      timeEnd(label);
+    }
+  }
+}
+
+export default function instrument(...args) {
+  return decorate(handleDescriptor, args);
+}

--- a/test/unit/instrument.spec.js
+++ b/test/unit/instrument.spec.js
@@ -40,6 +40,14 @@ describe('@instrument', function() {
     timeEndSpy.called.should.equal(true);
   });
 
+  it('uses class and method names for a default prefix', function() {
+    let labelPattern = new RegExp('Foo\\.instrumented-\\d+');
+    let label;
+    new Foo().instrumented();
+    label = timeSpy.getCall(0).args[0];
+    label.should.match(labelPattern);
+  });
+
   it('creates a unique label with a counter', function() {
     let dashNum = new RegExp('.*-(\\d+)$');
     let firstNum;
@@ -66,26 +74,6 @@ describe('@instrument', function() {
     logSpy.called.should.equal(true);
     console.log = LOG_NATIVE;
   });
-
-  it('supports a custom log function', function() {
-    let logged = false;
-
-    let myConsole = {
-      log() {
-        logged = true;
-      }
-    };
-
-    class Boo {
-      @instrument('custom', myConsole)
-      hoo() {
-        return;
-      }
-    }
-
-    new Boo().hoo();
-    logged.should.equal(true);
-  })
 
   it('supports a custom instrumentation object', function() {
     let timeCalled = false;

--- a/test/unit/instrument.spec.js
+++ b/test/unit/instrument.spec.js
@@ -8,7 +8,7 @@ describe('@instrument', function() {
   class Foo {
     @instrument
     instrumented() {
-      return;
+      return 'instrumented';
     }
 
     @instrument('foo')
@@ -109,6 +109,12 @@ describe('@instrument', function() {
     new Boo().hoo();
     timeCalled.should.equal(true);
     timeEndCalled.should.equal(true);
+  });
+
+  it('returns the value', function() {
+    let foo = new Foo();
+    let result = foo.instrumented();
+    result.should.equal('instrumented');
   });
 
 });

--- a/test/unit/instrument.spec.js
+++ b/test/unit/instrument.spec.js
@@ -77,7 +77,7 @@ describe('@instrument', function() {
     };
 
     class Boo {
-      @instrument('custom', {console:myConsole})
+      @instrument('custom', myConsole)
       hoo() {
         return;
       }
@@ -101,7 +101,7 @@ describe('@instrument', function() {
     }
 
     class Boo {
-      @instrument('custom', {console:myConsole})
+      @instrument('custom', myConsole)
       hoo() {
         return;
       }

--- a/test/unit/instrument.spec.js
+++ b/test/unit/instrument.spec.js
@@ -1,0 +1,114 @@
+import { spy } from 'sinon';
+import instrument from '../../lib/instrument';
+
+const CONSOLE_TIME = console.time;
+const CONSOLE_TIMEEND = console.timeEnd;
+
+describe('@instrument', function() {
+  class Foo {
+    @instrument
+    instrumented() {
+      return;
+    }
+
+    @instrument('foo')
+    instrumentedPrefix() {
+      return;
+    }
+
+    uninstrumented() {
+      return;
+    }
+  };
+
+  let timeSpy;
+  let timeEndSpy;
+
+  beforeEach(function () {
+    timeSpy = console.time = spy();
+    timeEndSpy = console.timeEnd = spy();
+  });
+
+  afterEach(function () {
+    console.time = CONSOLE_TIME;
+    console.timeEnd = CONSOLE_TIMEEND;
+  });
+
+  it('calls console.time and console.timeEnd', function() {
+    new Foo().instrumented();
+    timeSpy.called.should.equal(true);
+    timeEndSpy.called.should.equal(true);
+  });
+
+  it('creates a unique label with a counter', function() {
+    let dashNum = new RegExp('.*-(\\d+)$');
+    let firstNum;
+    let secondNum;
+    new Foo().instrumented();
+    new Foo().instrumentedPrefix();
+    firstNum = parseInt(timeSpy.getCall(0).args[0].replace(dashNum, '$1'), 10);
+    secondNum = parseInt(timeSpy.getCall(1).args[0].replace(dashNum, '$1'), 10);
+    secondNum.should.equal(firstNum + 1);
+  });
+
+  it('uses a supplied prefix for the label', function() {
+    new Foo().instrumentedPrefix();
+    timeSpy.getCall(0).args[0].should.match(/^foo-/);
+    timeEndSpy.getCall(0).args[0].should.match(/^foo-/);
+  });
+
+  it('uses a default instrumentation object if console.time is not available', function() {
+    const LOG_NATIVE = console.log;
+    let logSpy = console.log = spy();
+    console.time = null;
+    console.timeEnd = null;
+    new Foo().instrumented();
+    logSpy.called.should.equal(true);
+    console.log = LOG_NATIVE;
+  });
+
+  it('supports a custom log function', function() {
+    let logged = false;
+
+    let myConsole = {
+      log() {
+        logged = true;
+      }
+    };
+
+    class Boo {
+      @instrument('custom', {console:myConsole})
+      hoo() {
+        return;
+      }
+    }
+
+    new Boo().hoo();
+    logged.should.equal(true);
+  })
+
+  it('supports a custom instrumentation object', function() {
+    let timeCalled = false;
+    let timeEndCalled = false;
+
+    let myConsole = {
+      time(label) {
+        timeCalled = true;
+      },
+      timeEnd(label) {
+        timeEndCalled = true;
+      }
+    }
+
+    class Boo {
+      @instrument('custom', {console:myConsole})
+      hoo() {
+        return;
+      }
+    }
+    new Boo().hoo();
+    timeCalled.should.equal(true);
+    timeEndCalled.should.equal(true);
+  });
+
+});


### PR DESCRIPTION
This only uses `console.time`, rather than anything more complex.

If that is not the goal for the `@instrument` decorator, this could be renamed to `@time` or similar.