### PR TITLE
allow autobind on entire class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # core-decorators.js [![Build Status](https://travis-ci.org/jayphelps/core-decorators.js.svg?branch=master)](https://travis-ci.org/jayphelps/core-decorators.js)
-Library of [JavaScript decorators](https://github.com/wycats/javascript-decorators) (sometimes erroneously stated as ES2016 or ES7) inspired by languages that come with built-ins like @​override, @​deprecate, etc, similar to [pre-defined Annotations in Java](https://docs.oracle.com/javase/tutorial/java/annotations/predefined.html). Note that unlike Java annotations, decorators are functions which are applied at runtime.
-
-It also includes a single class decorator, `@mixin` for applying object descriptors to a given class.
+Library of [JavaScript decorators](https://github.com/wycats/javascript-decorators) (aka ES2016/ES7 decorators) inspired by languages that come with built-ins like @​override, @​deprecate, @​autobind, @​mixin and more. Popular with React/Angular, but is framework agnostic. Similar to [Annotations in Java](https://docs.oracle.com/javase/tutorial/java/annotations/predefined.html) but unlike Java annotations, decorators are functions which are applied at runtime.
 
 _*compiled code is intentionally not checked into this repo_
 
@@ -21,11 +19,11 @@ This can be consumed by any transpiler that supports decorators like [babel.js](
 * [@nonconfigurable](#nonconfigurable)
 * [@decorate](#decorate) :new:
 
-##### For Properties only
+##### For Properties
 * [@nonenumerable](#nonenumerable)
 * [@lazyInitialize](#lazyInitialize) :new:
 
-##### For Methods only
+##### For Methods
 * [@autobind](#autobind)
 * [@deprecate](#deprecate-alias-deprecated)
 * [@suppressWarnings](#suppresswarnings)
@@ -36,6 +34,7 @@ This can be consumed by any transpiler that supports decorators like [babel.js](
 * [@instrument](#instrument) :new:
 
 ##### For Classes
+* [@autobind](#autobind)
 * [@mixin](#mixin-alias-mixins) :new:
 
 
@@ -49,6 +48,8 @@ This can be consumed by any transpiler that supports decorators like [babel.js](
 
 Forces invocations of this function to always have `this` refer to the class instance, even if the function is passed around or would otherwise lose its `this` context. e.g. `var fn = context.method;` Popular with React components.
 
+Individual methods:
+
 ```js
 import { autobind } from 'core-decorators';
 
@@ -60,12 +61,37 @@ class Person {
 }
 
 let person = new Person();
-let getPerson = person.getPerson;
+let { getPerson } = person;
 
 getPerson() === person;
 // true
 ```
 
+Entire Class:
+
+```js
+import { autobind } from 'core-decorators';
+
+@autobind
+class Person {
+  getPerson() {
+  	return this;
+  }
+  
+  getPersonAgain() {
+    return this;
+  }
+}
+
+let person = new Person();
+let { getPerson, getPersonAgain } = person;
+
+getPerson() === person;
+// true
+
+getPersonAgain() === person;
+// true
+```
 ### @readonly
 
 Marks a property or method as not being writable.

--- a/test/unit/autobind.spec.js
+++ b/test/unit/autobind.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import autobind from '../../lib/autobind';
 
 const root = (typeof window !== 'undefined') ? window : global;
@@ -22,7 +23,8 @@ describe('@autobind', function () {
     barCount = 0;
 
     Bar = class Bar extends Foo {
-      @autobind
+      // Works when called as function as well
+      @autobind()
       getFoo() {
         const foo = super.getFoo();
         barCount++;
@@ -145,5 +147,46 @@ describe('@autobind', function () {
     getFoo2().should.equal(bar);
 
     barCount.should.equal(1);
+  });
+
+  it('can be used to autobind the entire class at once', function () {
+    // do not @autobind, which means start() should return `undefined` if
+    // it is detached from the instance
+    class Vehicle {
+      start() {
+        return this;
+      }
+    }
+
+    @autobind
+    class Car extends Vehicle {
+      constructor() {
+        super();
+        this.name = 'amazing';
+      }
+
+      get color() {
+        return 'red';
+      }
+
+      drive() {
+        return this;
+      }
+
+      stop() {
+        return this;
+      }
+    }
+
+    const car = new Car();
+    const { drive, stop, name, color, start } = car;
+    expect(drive()).to.equal(car);
+    drive().should.equal(car);
+    stop().should.equal(car);
+    name.should.equal('amazing');
+    color.should.equal('red');
+
+    // We didn't @autobind Vehicle
+    expect(start()).to.be.undefined;
   });
 });


### PR DESCRIPTION
```js
import { autobind } from 'core-decorators';

@autobind
class Person {
  getPerson() {
  	return this;
  }
  
  getPersonAgain() {
    return this;
  }
}

let person = new Person();
let { getPerson, getPersonAgain } = person;

getPerson() === person;
// true

getPersonAgain() === person;
// true
```