### PR TITLE
Adds extendDescriptor decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,26 @@ I *highly* recommend against using that globals build as it's quite strange you'
 ##### For Properties and Methods
 * [@readonly](#readonly)
 * [@nonconfigurable](#nonconfigurable)
-* [@decorate](#decorate) :new:
+* [@decorate](#decorate)
+* [@extendDescriptor](#extendDescriptor) :new:
 
 ##### For Properties
 * [@nonenumerable](#nonenumerable)
-* [@lazyInitialize](#lazyinitialize) :new:
+* [@lazyInitialize](#lazyinitialize)
 
 ##### For Methods
 * [@autobind](#autobind)
 * [@deprecate](#deprecate-alias-deprecated)
 * [@suppressWarnings](#suppresswarnings)
-* [@enumerable](#enumerable) :new:
+* [@enumerable](#enumerable)
 * [@override](#override)
 * [@debounce](#debounce)
-* [@throttle](#throttle) :new:
-* [@time](#time) :new:
+* [@throttle](#throttle)
+* [@time](#time)
 
 ##### For Classes
-* [@autobind](#autobind) :new:
-* [@mixin](#mixin-alias-mixins) :new:
+* [@autobind](#autobind)
+* [@mixin](#mixin-alias-mixins)
 
 ## Helpers
 
@@ -433,6 +434,35 @@ let myConsole = {
   timeEnd: function(label) { /* custom timeEnd method */ },
   log: function(str) { /* custom log method */ }
 }
+```
+
+### @extendDescriptor
+
+Extends the new property descriptor with the descriptor from the super/parent class prototype. Although useful in various circumstances, it's particularly helpful to address the fact that getters and setters share a single descriptor so overriding only a getter or only a setter will blow away the other, without this decorator.
+
+```js
+class Base {
+  @nonconfigurable
+  get foo() {
+    return `hello ${this._foo}`;
+  }
+}
+
+class Derived extends Base {
+  @extendDescriptor
+  set foo(value) {
+    this._foo = value;
+  }
+}
+
+const derived = new Derived();
+derived.foo = 'bar';
+derived.foo === 'hello bar';
+// true
+
+const desc = Object.getOwnPropertyDescriptor(Derived.prototype, 'foo');
+desc.configurable === false;
+// true
 ```
 
 ### applyDecorators() helper

--- a/src/core-decorators.js
+++ b/src/core-decorators.js
@@ -1,6 +1,6 @@
 /**
  * core-decorators.js
- * (c) 2016 Jay Phelps
+ * (c) 2016 Jay Phelps and contributors
  * MIT Licensed
  * https://github.com/jayphelps/core-decorators.js
  * @license
@@ -20,6 +20,7 @@ export { default as decorate } from './decorate';
 export { default as mixin, default as mixins } from './mixin';
 export { default as lazyInitialize } from './lazy-initialize';
 export { default as time } from './time';
+export { default as extendDescriptor } from './extendDescriptor';
 
 // Helper to apply decorators to a class without transpiler support
 export { default as applyDecorators } from './applyDecorators';

--- a/src/extendDescriptor.js
+++ b/src/extendDescriptor.js
@@ -1,0 +1,18 @@
+import { decorate } from './private/utils';
+
+function handleDescriptor(target, key, descriptor) {
+  const superKlass = Object.getPrototypeOf(target);
+  const superDesc = Object.getOwnPropertyDescriptor(superKlass, key);
+
+  return {
+    ...superDesc,
+    value: descriptor.value,
+    initializer: descriptor.initializer,
+    get: descriptor.get || superDesc.get,
+    set: descriptor.set || superDesc.set
+  };
+}
+
+export default function extendDescriptor(...args) {
+  return decorate(handleDescriptor, args);
+}

--- a/test/unit/extendDescriptor.js
+++ b/test/unit/extendDescriptor.js
@@ -1,0 +1,93 @@
+import extendDescriptor from '../../lib/extendDescriptor';
+import enumerable from '../../lib/enumerable';
+import nonenumerable from '../../lib/nonenumerable';
+
+describe('@extendDescriptor', function () {
+  class Base {
+    get first() {
+      return this._first;
+    }
+
+    set second(value) {
+      this._second = value;
+    }
+
+    set third(value) {
+      throw new Error('should not be called');
+    }
+
+    @nonenumerable
+    fourth = 'fourth';
+
+    @enumerable
+    fifth() {
+      throw new Error('should not be called');
+    }
+  }
+
+  class Middle extends Base {}
+
+  class Derived extends Middle {
+    @extendDescriptor
+    set first(value) {
+      this._first = value;
+    }
+
+    @extendDescriptor
+    get second() {
+      return this._second;
+    }
+
+    @extendDescriptor
+    get third() {
+      return this._third;
+    }
+
+    set third(value) {
+      this._third = value;
+    }
+
+    @extendDescriptor
+    fourth = 'fourth';
+
+    @extendDescriptor
+    fifth() {
+      return 'fifth';
+    }
+  }
+
+  let derived;
+
+  beforeEach(() => {
+    derived = new Derived();
+  });
+
+  afterEach(() => {
+    derived = null;
+  });
+
+  it('extends getters/setters', function () {
+    derived.first = 'first';
+    derived.first.should.equal('first');
+
+    derived.second = 'second';
+    derived.second.should.equal('second');
+
+    derived.third = 'third';
+    derived.third.should.equal('third');
+  });
+
+  it('extends property initializers', function () {
+    Object.getOwnPropertyDescriptor(Derived.prototype, 'fourth');
+      .enumerable.should.equal(false);
+
+    derived.fourth.should.equal('fourth');
+  });
+
+  it('extends property methods', function () {
+    Object.getOwnPropertyDescriptor(Derived.prototype, 'fifth');
+      .enumerable.should.equal(true);
+
+    derived.fifth().should.equal('fourth');
+  });
+});


### PR DESCRIPTION
Adds a new `@extendDescriptor` decorators, closing #50.

Extends the new property descriptor with the descriptor from the super/parent class prototype. Although useful in various circumstances, it's particularly helpful to address the fact that getters and setters share a single descriptor so overriding only a getter or only a setter will blow away the other, without this decorator.

```js
class Base {
  @nonconfigurable
  get foo() {
    return `hello ${this._foo}`;
  }
}

class Derived extends Base {
  @extendDescriptor
  set foo(value) {
    this._foo = value;
  }
}

const derived = new Derived();
derived.foo = 'bar';
derived.foo === 'hello bar';
// true

const desc = Object.getOwnPropertyDescriptor(Derived.prototype, 'foo');
desc.configurable === false;
// true
```
Huge thanks to @silkentrance for request and helping flesh out the code.