### PR TITLE
[Bug fix] @autobind and @mixin decorators should be able to handle ES6 Symbols

### DIFF
--- a/src/autobind.js
+++ b/src/autobind.js
@@ -41,7 +41,8 @@ function getBoundSuper(obj, fn) {
 function autobindClass(klass) {
   const descs = getOwnPropertyDescriptors(klass.prototype);
 
-  for (const [key, desc] of descs) {
+  for (const key in descs) {
+    const desc = descs[key];
     if (typeof desc.value !== 'function' || key === 'constructor') {
       continue;
     }

--- a/src/autobind.js
+++ b/src/autobind.js
@@ -1,4 +1,4 @@
-import { decorate, createDefaultSetter, getOwnPropertyDescriptors } from './private/utils';
+import { decorate, createDefaultSetter, getOwnPropertyDescriptors, getOwnKeys } from './private/utils';
 const { defineProperty } = Object;
 
 function bind(fn, context) {
@@ -41,7 +41,7 @@ function getBoundSuper(obj, fn) {
 function autobindClass(klass) {
   const descs = getOwnPropertyDescriptors(klass.prototype);
 
-  for (const key in descs) {
+  for (const key of getOwnKeys(descs)) {
     const desc = descs[key];
     if (typeof desc.value !== 'function' || key === 'constructor') {
       continue;

--- a/src/autobind.js
+++ b/src/autobind.js
@@ -41,8 +41,7 @@ function getBoundSuper(obj, fn) {
 function autobindClass(klass) {
   const descs = getOwnPropertyDescriptors(klass.prototype);
 
-  for (const key in descs) {
-    const desc = descs[key];
+  for (const [key, desc] of descs) {
     if (typeof desc.value !== 'function' || key === 'constructor') {
       continue;
     }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,4 +1,4 @@
-import { getOwnPropertyDescriptors } from './private/utils';
+import { getOwnPropertyDescriptors, getOwnKeys } from './private/utils';
 
 const { defineProperty } = Object;
 
@@ -10,7 +10,7 @@ function handleClass(target, mixins) {
   for (let i = 0, l = mixins.length; i < l; i++) {
     const descs = getOwnPropertyDescriptors(mixins[i]);
 
-    for (const key in descs) {
+    for (const key of getOwnKeys(descs)) {
       if (!(key in target.prototype)) {
         defineProperty(target.prototype, key, descs[key]);
       }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,9 +10,9 @@ function handleClass(target, mixins) {
   for (let i = 0, l = mixins.length; i < l; i++) {
     const descs = getOwnPropertyDescriptors(mixins[i]);
 
-    for (const [key, desc] of descs) {
+    for (const key in descs) {
       if (!(key in target.prototype)) {
-        defineProperty(target.prototype, key, desc);
+        defineProperty(target.prototype, key, descs[key]);
       }
     }
   }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,9 +10,9 @@ function handleClass(target, mixins) {
   for (let i = 0, l = mixins.length; i < l; i++) {
     const descs = getOwnPropertyDescriptors(mixins[i]);
 
-    for (const key in descs) {
+    for (const [key, desc] of descs) {
       if (!(key in target.prototype)) {
-        defineProperty(target.prototype, key, descs[key]);
+        defineProperty(target.prototype, key, desc);
       }
     }
   }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -14,10 +14,15 @@ function hasProperty(prop, obj) {
   // prop actually exists in given object/prototypes' chain.
   if (buggySymbol(prop)) {
     do {
+      if (obj === Object.prototype) {
+        // Polyfill assigns undefined as value for stored symbol key.
+        // We can assume in this special case if there is nothing assigned it doesn't exist.
+        return typeof(obj[prop]) !== 'undefined';
+      }
       if (obj.hasOwnProperty(prop)) {
         return true;
       }
-    } while ((obj = getPrototypeOf(obj)) && obj !== Object.prototype);
+    } while (obj = getPrototypeOf(obj));
     return false;
   } else {
     return prop in obj;

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -53,7 +53,7 @@ export function metaFor(obj) {
   return obj[META_KEY];
 }
 
-const getOwnKeys = getOwnPropertySymbols
+export const getOwnKeys = getOwnPropertySymbols
     ? function (object) {
         return getOwnPropertyNames(object)
           .concat(getOwnPropertySymbols(object));

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -62,13 +62,10 @@ const getOwnKeys = getOwnPropertySymbols
 
 
 export function getOwnPropertyDescriptors(obj) {
-  const descs = {};
-
-  getOwnKeys(obj).forEach(
-    key => (descs[key] = getOwnPropertyDescriptor(obj, key))
-  );
-
-  return descs;
+  return getOwnKeys(obj).map(key => [
+    key,
+    getOwnPropertyDescriptor(obj, key)
+  ]);
 }
 
 export function createDefaultSetter(key) {

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -62,10 +62,13 @@ const getOwnKeys = getOwnPropertySymbols
 
 
 export function getOwnPropertyDescriptors(obj) {
-  return getOwnKeys(obj).map(key => [
-    key,
-    getOwnPropertyDescriptor(obj, key)
-  ]);
+  const descs = {};
+
+  getOwnKeys(obj).forEach(
+    key => (descs[key] = getOwnPropertyDescriptor(obj, key))
+  );
+
+  return descs;
 }
 
 export function createDefaultSetter(key) {

--- a/test/unit/autobind.spec.js
+++ b/test/unit/autobind.spec.js
@@ -275,4 +275,19 @@ describe('@autobind', function () {
     const method3 = B.prototype.method;
     method3.call({ test: 'second' }).should.equal('second');
   });
+
+  it('correctly binds class with symbol properties', function () {
+    const parkHash = Symbol('park');
+
+    @autobind
+    class Car {
+      [parkHash]() {
+        return this;
+      }
+    }
+
+    const car = new Car();
+    const park = car[parkHash];
+    park().should.equal(car);
+  })
 });

--- a/test/unit/mixin.spec.js
+++ b/test/unit/mixin.spec.js
@@ -62,4 +62,16 @@ describe('@mixin', function () {
     foo.getStuff4().should.equal('stuff4');
     foo.stuff5.should.equal('stuff5');
   });
+
+  it('correctly adds symbols', function () {
+    const symbolHash = Symbol('mixin');
+    const SymbolMixin = {
+      [symbolHash]() {
+        return 'symbolHash';
+      }
+    };
+    const foo = new (applyMixins(SymbolMixin));
+
+    foo[symbolHash]().should.equal('symbolHash');
+  });
 });


### PR DESCRIPTION
Greets,

Writing my own project I found, it is not possible to use `autobind` and `mixin` decorators with Symbols beside.
This should works out of the box, since whole logic is already done in core-decorators' internals, but due to not enumerable nature of Symbols, it is not possible to iterate over them using `for in` construction (`Object.keys()` also doesn't work for those). Both, `mixin` and `autobind`shouldn't really care if something is enumerable or not.

Cheers!