### PR TITLE
Add profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ I *highly* recommend against using that globals build as it's quite strange you'
 * [@debounce](#debounce)
 * [@throttle](#throttle)
 * [@time](#time)
+* [@profile](#profile) :new:
 
 ##### For Classes
 * [@autobind](#autobind)
@@ -89,7 +90,7 @@ class Person {
   getPerson() {
   	return this;
   }
-  
+
   getPersonAgain() {
     return this;
   }
@@ -441,6 +442,38 @@ let myConsole = {
   log: function(str) { /* custom log method */ }
 }
 ```
+
+### @profile
+
+Uses `console.profile` and `console.profileEnd` to provide function profiling with a unique label whose default prefix is `ClassName.method`. Supply a first argument to override the prefix:
+
+```js
+class Bird {
+  @profile('sing')
+  sing() {
+  }
+}
+
+var bird = new Bird();
+bird.sing(); // Adds a profile with label sing and marked as run 1
+bird.sing(); // Adds a profile with label sing and marked as run 2
+```
+
+Because profiling is expensive, you may not want to run it every time the function is called. Supply a second argument of `true` to have the profiling only run once:
+
+```js
+class Bird {
+  @profile(null, true)
+  sing() {
+  }
+}
+
+var bird = new Bird();
+bird.sing(); // Adds a profile with label Bird.sing
+bird.sing(); // Does nothing
+```
+
+Profiling is currently only supported in Chrome 53+, Firefox, and Edge. Unfortunately this feature can't be polyfilled or faked, so if used in an unsupported browser or Node.js then this decorator will automatically disable itself.
 
 ### @extendDescriptor
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "camelcase": "^2.0.1",
     "chai": "^3.2.0",
     "glob": "^6.0.1",
+    "global-wrap": "^2.0.0",
     "interop-require": "1.0.0",
     "lodash": "4.10.0",
     "mocha": "^2.2.5",

--- a/src/core-decorators.js
+++ b/src/core-decorators.js
@@ -21,6 +21,7 @@ export { default as mixin, default as mixins } from './mixin';
 export { default as lazyInitialize } from './lazy-initialize';
 export { default as time } from './time';
 export { default as extendDescriptor } from './extendDescriptor';
+export { default as profile } from './profile';
 
 // Helper to apply decorators to a class without transpiler support
 export { default as applyDecorators } from './applyDecorators';

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,0 +1,56 @@
+import { decorate } from './private/utils';
+
+// Exported for mocking in tests
+export const defaultConsole = {
+  profile: console.profile ? console.profile.bind(console) : () => {},
+  profileEnd: console.profileEnd ? console.profileEnd.bind(console) : () => {},
+  warn: console.warn.bind(console)
+};
+
+function handleDescriptor(target, key, descriptor, [prefix = null, once = false, console = defaultConsole]) {
+  if (!profile.__enabled) {
+    if (!profile.__warned) {
+      console.warn('Console.profile is not supported. All @profile decorators are disabled.');
+      profile.__warned = true;
+    }
+    return descriptor;
+  }
+
+  const fn = descriptor.value;
+
+  if (prefix === null) {
+    prefix = `${target.constructor.name}.${key}`;
+  }
+
+  if (typeof fn !== 'function') {
+    throw new SyntaxError(`@profile can only be used on functions, not: ${fn}`);
+  }
+
+  let ran = false;
+
+  return {
+    ...descriptor,
+    value() {
+      const label = `${prefix}`;
+      if (!once || once && !ran) {
+        console.profile(label);
+        ran = true;
+      }
+
+      try {
+        return fn.apply(this, arguments);
+      } finally {
+        console.profileEnd(label);
+      }
+    }
+  }
+}
+
+export default function profile(...args) {
+  return decorate(handleDescriptor, args);
+}
+
+// Only Chrome, Firefox, and Edge support profile.
+// Exposing properties for testing.
+profile.__enabled = !!console.profile;
+profile.__warned = false;

--- a/test/unit/profile.spec.js
+++ b/test/unit/profile.spec.js
@@ -1,0 +1,159 @@
+import { spy } from 'sinon';
+import applyDecorators from '../../lib/applyDecorators';
+import profile, { defaultConsole } from '../../lib/profile';
+
+const CONSOLE_PROFILE = defaultConsole.profile;
+const CONSOLE_PROFILEEND = defaultConsole.profileEnd;
+const CONSOLE_WARN = defaultConsole.warn;
+
+profile.__enabled = true;
+
+describe('@profile', function() {
+  class Foo {
+    @profile
+    profiled() {
+      return 'profiled';
+    }
+
+    @profile('foo')
+    profiledPrefix() {
+      return;
+    }
+
+    @profile(null, true)
+    profileOnce() {
+      return;
+    }
+
+    unprofiled() {
+      return;
+    }
+
+    @profile
+    iThrowAnError() {
+      throw 'foobar';
+    }
+  };
+
+  let profileSpy;
+  let profileEndSpy;
+  let warnSpy;
+
+  beforeEach(function () {
+    profileSpy = defaultConsole.profile = spy();
+    profileEndSpy = defaultConsole.profileEnd = spy();
+    warnSpy = defaultConsole.warn = spy();
+  });
+
+  afterEach(function () {
+    defaultConsole.profile = CONSOLE_PROFILE;
+    defaultConsole.profileEnd = CONSOLE_PROFILEEND;
+    defaultConsole.warn = CONSOLE_WARN;
+  });
+
+  it('calls console.profile and console.profileEnd', function() {
+    new Foo().profiled();
+    profileSpy.called.should.equal(true);
+    profileEndSpy.called.should.equal(true);
+  });
+
+  it('calls console.profile and console.profileEnd once when flag is on', function() {
+    const foo = new Foo();
+    foo.profileOnce();
+    foo.profileOnce();
+
+    profileSpy.calledOnce.should.equal(true);
+  });
+
+  it('calls console.profileEnd even if the called method throws', function() {
+    try {
+      new Foo().iThrowAnError();
+    } catch (e) {
+      e.should.equal('foobar');
+    }
+
+    profileSpy.called.should.equal(true);
+    profileEndSpy.called.should.equal(true);
+  });
+
+  it('uses class and method names for a default prefix', function() {
+    let labelPattern = new RegExp('Foo\\.profiled');
+    let label;
+    new Foo().profiled();
+    label = profileSpy.getCall(0).args[0];
+    label.should.match(labelPattern);
+  });
+
+  it('uses a supplied prefix for the label', function() {
+    new Foo().profiledPrefix();
+    profileSpy.getCall(0).args[0].should.match(/^foo/);
+    profileEndSpy.getCall(0).args[0].should.match(/^foo/);
+  });
+
+  it('supports a custom profileation object', function() {
+    let profileCalled = false;
+    let profileEndCalled = false;
+
+    let myConsole = {
+      profile(label) {
+        profileCalled = true;
+      },
+      profileEnd(label) {
+        profileEndCalled = true;
+      }
+    }
+
+    class Boo {
+      @profile('custom', false, myConsole)
+      hoo() {
+        return;
+      }
+    }
+    new Boo().hoo();
+    profileCalled.should.equal(true);
+    profileEndCalled.should.equal(true);
+  });
+
+  it('returns the value', function() {
+    let foo = new Foo();
+    let result = foo.profiled();
+    result.should.equal('profiled');
+  });
+
+  describe('when disabled', function() {
+    class Bar {
+      disabledProfile() {
+        return;
+      }
+    }
+
+    beforeEach(function() {
+      profile.__enabled = false;
+    });
+
+    afterEach(function() {
+      profile.__enabled = true;
+    });
+
+    it('should send a warning', function() {
+      profile.__warned = false;
+
+      applyDecorators(Bar, {
+        disabledProfile: [profile]
+      });
+
+      warnSpy.called.should.equal(true);
+    });
+
+    it('should leave descriptor alone', function() {
+      const oldBarDisabledProfile = Bar.prototype.disabledProfile = spy();
+
+      applyDecorators(Bar, {
+        disabledProfile: [profile]
+      });
+
+      Bar.prototype.disabledProfile.should.equal(oldBarDisabledProfile);
+    });
+  })
+
+});


### PR DESCRIPTION
The `@profile` decorator allows for profiling a method. Useful to
diagnose performance issues in applications.