### PR TITLE
Add support for Webpack & Rollup Tree-shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,17 @@
 {
-  "presets": ["es2015"],
+  "presets": [["es2015", { "modules": false }]],
   "plugins": [
     "transform-object-rest-spread",
     "transform-flow-strip-types",
     "transform-decorators-legacy",
     "transform-class-properties"
-  ]
+  ],
+  "env": {
+    "es": {},
+    "development": {
+      "plugins": [
+        "transform-es2015-modules-commonjs"
+      ]
+    }
+  }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": ["es2015"],
+  "plugins": [
+    "transform-object-rest-spread",
+    "transform-flow-strip-types",
+    "transform-decorators-legacy",
+    "transform-class-properties"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /lib/
+/es/
 /node_modules/
 core-decorators.js

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "babel --out-dir lib src",
     "build-bower": "babel-node scripts/build-bower.js",
-    "test": "npm run build && mocha --compilers js:babel/register --require babel/polyfill \"test/**/*.spec.js\""
+    "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
   "repository": {
     "type": "git",
@@ -43,15 +43,22 @@
   },
   "homepage": "https://github.com/jayphelps/core-decorators.js",
   "devDependencies": {
-    "babel": "^5.4.7",
-    "camelcase": "^2.0.1",
-    "chai": "^3.2.0",
-    "glob": "^6.0.1",
+    "babel-cli": "^6.24.0",
+    "babel-core": "^6.24.0",
+    "babel-plugin-transform-class-properties": "^6.23.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-es2015": "^6.24.0",
+    "camelcase": "^4.1.0",
+    "chai": "^3.5.0",
+    "glob": "^7.1.1",
     "global-wrap": "^2.0.0",
     "interop-require": "1.0.0",
-    "lodash": "4.10.0",
-    "mocha": "^2.2.5",
-    "sinon": "^1.15.4",
-    "sinon-chai": "^2.8.0"
+    "lodash": "4.17.4",
+    "mocha": "^3.2.0",
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.15.0",
   "description": "Library of JavaScript stage-0 decorators (aka ES2016/ES7 decorators but that's not accurate!) inspired by languages that come with built-ins like @​override, @​deprecate, @​autobind, @​mixin and more! Works great with React/Angular/more!",
   "main": "lib/core-decorators.js",
+  "module": "es/core-decorators.js",
+  "jsnext:main": "es/core-decorators.js",
   "files": [
     "lib",
     "src",
@@ -11,6 +13,7 @@
   ],
   "scripts": {
     "build": "babel --out-dir lib src",
+    "build-es": "BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
     "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
@@ -47,6 +50,7 @@
     "babel-core": "^6.24.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-polyfill": "^6.23.0",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,7 +1,0 @@
-{
-  "optional": [
-    "es7.objectRestSpread",
-    "es7.classProperties",
-    "es7.decorators"
-  ]
-}

--- a/test/.babelrc
+++ b/test/.babelrc
@@ -1,6 +1,0 @@
-{
-  "optional": [
-    "es7.decorators",
-    "es7.classProperties"
-  ]
-}


### PR DESCRIPTION
This PR adds support for tree-shaking by building an alternative version which uses ES modules rather than CommonJS ones, inside `es`. 

This version will be loaded by bundlers that support the `module` or `jsnext:main` package.json fields (only webpack & rollup afaik), other bundlers and runtimes will fallback to the CommonJS version (inside `lib`).

This PR is an alternative to PR https://github.com/jayphelps/core-decorators.js/pull/93, as it also updates babel to version 6. Other dependencies have also been updated but that can be reverted if requested as it is out of scope for this PR.