### PR TITLE
Switched debounce and throttle from timeout

### DIFF
--- a/test/unit/debounce.spec.js
+++ b/test/unit/debounce.spec.js
@@ -1,3 +1,4 @@
+import { useFakeTimers } from 'sinon';
 import debounce from '../../lib/debounce';
 
 class Editor {
@@ -16,45 +17,47 @@ class Editor {
 
 describe('@debounce', function () {
   let editor;
+  let clock;
 
   beforeEach(function () {
     editor = new Editor();
+    clock = useFakeTimers(Date.now());
   });
 
-  it('invokes function only once', function (done) {
+  afterEach(function () {
+    clock.restore();
+  });
+
+  it('invokes function only once', function () {
     editor.updateCounter1();
     editor.counter.should.equal(0);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      done();
-    }, 600);
+    clock.tick(600);
+
+    editor.counter.should.equal(1);
   });
 
-  it('invokes function immediately and only once if "immediate" option is true', function (done) {
+  it('invokes function immediately and only once if "immediate" option is true', function () {
     editor.updateCounter2();
     editor.counter.should.equal(1);
 
-    // should still be 1 because 600ms hasn't yet passed
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-    }, 400);
+    clock.tick(400);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      done();
-    }, 600);
+    editor.counter.should.equal(1);
+
+    clock.tick(200);
+
+    editor.counter.should.equal(1);
   });
 
-  it('does not share timers between instances', function (done) {
+  it('does not share timers between instances', function () {
     let editor2 = new Editor();
     editor.updateCounter1();
     editor2.updateCounter1();
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      editor2.counter.should.equal(1);
-      done();
-    }, 600);
+    clock.tick(600);
+
+    editor.counter.should.equal(1);
+    editor2.counter.should.equal(1);
   });
 });

--- a/test/unit/throttle.spec.js
+++ b/test/unit/throttle.spec.js
@@ -1,3 +1,4 @@
+import { useFakeTimers } from 'sinon';
 import throttle from '../../lib/throttle';
 
 const defaultValue = {};
@@ -27,23 +28,28 @@ class Editor {
 
 describe('@throttle', function () {
   let editor;
+  let clock;
 
   beforeEach(function () {
     editor = new Editor();
+    clock = useFakeTimers(Date.now());
   });
 
-  it('invokes function only once', function (done) {
+  afterEach(function () {
+    clock.restore();
+  })
+
+  it('invokes function only once', function () {
     editor.updateCounter1(1);
     editor.counter.should.equal(1);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      editor.value.should.equal(1);
-      done();
-    }, 600);
+    clock.tick(600);
+
+    editor.counter.should.equal(1);
+    editor.value.should.equal(1);
   });
 
-  it('invokes function only twice', function (done) {
+  it('invokes function only twice', function () {
     editor.updateCounter1(1);
     editor.updateCounter1(2);
     editor.updateCounter1(3);
@@ -51,72 +57,68 @@ describe('@throttle', function () {
     editor.counter.should.equal(1);
     editor.value.should.equal(1);
 
-    setTimeout(() => {
-      editor.counter.should.equal(2);
-      editor.value.should.equal(4);
-      done();
-    }, 600);
+    clock.tick(600);
+
+    editor.counter.should.equal(2);
+    editor.value.should.equal(4);
   });
 
-  it('invokes function delay and only once if "leading" option is false', function (done) {
+  it('invokes function delay and only once if "leading" option is false', function () {
     editor.updateCounter2(1);
     editor.counter.should.equal(0);
     editor.value.should.equal(defaultValue);
 
-    // should still be 1 because 500ms hasn't yet passed
-    setTimeout(() => {
-      editor.counter.should.equal(0);
-      editor.value.should.equal(defaultValue);
-    }, 400);
+    clock.tick(400);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      editor.value.should.equal(1);
-      done();
-    }, 600);
+    // should still be 1 because 500ms hasn't yet passed
+    editor.counter.should.equal(0);
+    editor.value.should.equal(defaultValue);
+
+    clock.tick(200);
+
+    editor.counter.should.equal(1);
+    editor.value.should.equal(1);
   });
 
-   it('uses last arguments for leading: false, trailing: true (issue #94)', function (done) {
+   it('uses last arguments for leading: false, trailing: true (issue #94)', function () {
     editor.updateCounter2(1);
     editor.updateCounter2(2);
     editor.updateCounter2(3);
     editor.counter.should.equal(0);
     editor.value.should.equal(defaultValue);
 
-    // should still be 1 because 500ms hasn't yet passed
-    setTimeout(() => {
-      editor.counter.should.equal(0);
-      editor.value.should.equal(defaultValue);
-    }, 400);
+    clock.tick(400);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      editor.value.should.equal(3);
-      done();
-    }, 600);
+    // should still be 1 because 500ms hasn't yet passed
+    editor.counter.should.equal(0);
+    editor.value.should.equal(defaultValue);
+
+    clock.tick(200);
+
+    editor.counter.should.equal(1);
+    editor.value.should.equal(3);
   });
 
-  it('does not invoke function if "leading" and "trailing" options are both false', function (done) {
+  it('does not invoke function if "leading" and "trailing" options are both false', function () {
     editor.updateCounter3(1);
     editor.counter.should.equal(0);
     editor.value.should.equal(defaultValue);
 
+    clock.tick(400);
+
     // should still be 0 because leading call a canceled
-    setTimeout(() => {
-      editor.counter.should.equal(0);
-      editor.value.should.equal(defaultValue);
-      editor.updateCounter3(2);
-    }, 400);
+    editor.counter.should.equal(0);
+    editor.value.should.equal(defaultValue);
+    editor.updateCounter3(2);
+
+    clock.tick(200);
 
     // should still be 0 because trailing call a canceled
-    setTimeout(() => {
-      editor.counter.should.equal(0);
-      editor.value.should.equal(defaultValue);
-      done();
-    }, 600);
+    editor.counter.should.equal(0);
+    editor.value.should.equal(defaultValue);
   });
 
-  it('does not share timers and args between instances', function (done) {
+  it('does not share timers and args between instances', function () {
     let editor2 = new Editor();
     editor.updateCounter1(1);
     editor2.updateCounter1(2);
@@ -126,12 +128,11 @@ describe('@throttle', function () {
     editor.value.should.equal(1);
     editor2.value.should.equal(2);
 
-    setTimeout(() => {
-      editor.counter.should.equal(1);
-      editor2.counter.should.equal(1);
-      editor.value.should.equal(1);
-      editor2.value.should.equal(2);
-      done();
-    }, 600);
+    clock.tick(600);
+
+    editor.counter.should.equal(1);
+    editor2.counter.should.equal(1);
+    editor.value.should.equal(1);
+    editor2.value.should.equal(2);
   });
 });


### PR DESCRIPTION
Tests for debounce and throttle will now use fake timers to increase
test speed.