### PR TITLE
Deprecate decorators that overlap with lodash-decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ A globals version is available [here in the artifact repo](https://github.com/ja
 
 I *highly* recommend against using that globals build as it's quite strange you're using decorators (a proposed future feature of JavaScript) while not using ES2015 modules, a spec ratified feature used by nearly every modern framework. Also--[bower is on its deathbed](https://github.com/bower/bower/pull/1748) and IMO for very good reasons.
 
+## Need lodash utilities as decorators?
+
+core-decorators aims to provide decorators that are fundamental to JavaScript itself--mostly things you could do with normal `Object.defineProperty` but not as easily when using ES2015 classes. Things like debouncing, throttling, and other more opinionated decorators are being phased out in favor of [lodash-decorators](https://www.npmjs.com/package/lodash-decorators) which wraps applicable lodash utilities as decorators. We don't want to duplicate the effort of lodash, which has years and years of robust testing and bugfixes.
+
 ## Decorators
 
 ##### For Properties and Methods
 * [@readonly](#readonly)
 * [@nonconfigurable](#nonconfigurable)
 * [@decorate](#decorate)
-* [@extendDescriptor](#extenddescriptor) :new:
+* [@extendDescriptor](#extenddescriptor)
 
 ##### For Properties
 * [@nonenumerable](#nonenumerable)
@@ -40,18 +44,18 @@ I *highly* recommend against using that globals build as it's quite strange you'
 * [@suppressWarnings](#suppresswarnings)
 * [@enumerable](#enumerable)
 * [@override](#override)
-* [@debounce](#debounce)
-* [@throttle](#throttle)
+* [@debounce](#debounce) :no_entry_sign: DEPRECATED
+* [@throttle](#throttle) :no_entry_sign: DEPRECATED
 * [@time](#time)
-* [@profile](#profile) :new:
+* [@profile](#profile)
 
 ##### For Classes
 * [@autobind](#autobind)
-* [@mixin](#mixin-alias-mixins)
+* [@mixin](#mixin-alias-mixins) :no_entry_sign: DEPRECATED
 
 ## Helpers
 
-* [applyDecorators()](#applydecorators-helper) :new:
+* [applyDecorators()](#applydecorators-helper)
 
 ## Docs
 
@@ -186,7 +190,7 @@ person.facepalmHarder();
 //
 ```
 
-### @debounce
+### @debounce :no_entry_sign: DEPRECATED
 
 Creates a new debounced function which will be invoked after `wait` milliseconds since the time it was invoked. Default timeout is 300 ms.
 
@@ -206,7 +210,7 @@ class Editor {
 }
 ```
 
-### @throttle
+### @throttle :no_entry_sign: DEPRECATED
 
 Creates a new throttled function which will be invoked in every `wait` milliseconds. Default timeout is 300 ms.
 
@@ -380,7 +384,7 @@ editor.hugeBuffer;
 // createHugeBuffer() is not called again
 ```
 
-### @mixin (alias: @mixins)
+### @mixin (alias: @mixins) :no_entry_sign: DEPRECATED
 
 Mixes in all property descriptors from the provided Plain Old JavaScript Objects (aka POJOs) as arguments. Mixins are applied in the order they are passed, but do **not** override descriptors already on the class, including those inherited traditionally.
 

--- a/src/autobind.js
+++ b/src/autobind.js
@@ -1,16 +1,6 @@
 import { decorate, createDefaultSetter,
-  getOwnPropertyDescriptors, getOwnKeys } from './private/utils';
+  getOwnPropertyDescriptors, getOwnKeys, bind } from './private/utils';
 const { defineProperty, getPrototypeOf } = Object;
-
-function bind(fn, context) {
-  if (fn.bind) {
-    return fn.bind(context);
-  } else {
-    return function __autobind__() {
-      return fn.apply(context, arguments);
-    };
-  }
-}
 
 let mapStore;
 

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,4 +1,4 @@
-import { decorate, metaFor } from './private/utils';
+import { decorate, metaFor, internalDeprecation } from './private/utils';
 
 const DEFAULT_TIMEOUT = 300;
 
@@ -34,5 +34,6 @@ function handleDescriptor(target, key, descriptor, [wait = DEFAULT_TIMEOUT, imme
 }
 
 export default function debounce(...args) {
+  internalDeprecation('@debounce is deprecated and will be removed shortly. Use @debounce from lodash-decorators.\n\n  https://www.npmjs.com/package/lodash-decorators');
   return decorate(handleDescriptor, args);
 }

--- a/src/deprecate.js
+++ b/src/deprecate.js
@@ -1,4 +1,4 @@
-import { decorate } from './private/utils';
+import { decorate, warn } from './private/utils';
 
 const DEFAULT_MSG = 'This function will be removed in future versions.';
 
@@ -16,7 +16,7 @@ function handleDescriptor(target, key, descriptor, [msg = DEFAULT_MSG, options =
   return {
     ...descriptor,
     value: function deprecationWrapper() {
-      console.warn(`DEPRECATION ${methodSignature}: ${msg}`);
+      warn(`DEPRECATION ${methodSignature}: ${msg}`);
       return descriptor.value.apply(this, arguments);
     }
   };

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,4 +1,4 @@
-import { decorate } from './private/utils';
+import { decorate, internalDeprecation } from './private/utils';
 
 function toObject(cache, value) {
   if (value === Object(value)) {
@@ -34,8 +34,6 @@ function metaForDescriptor(descriptor) {
 }
 
 function handleDescriptor(target, key, descriptor) {
-  console.warn('DEPRECATION: @memoize is deprecated and will be removed shortly. Use @decorate with lodash\'s memoize helper.\n\n  https://github.com/jayphelps/core-decorators.js#decorate');
-
   const { fn, wrapKey } = metaForDescriptor(descriptor);
   const argumentCache = new WeakMap();
   const signatureCache = Object.create(null);
@@ -67,5 +65,6 @@ function handleDescriptor(target, key, descriptor) {
 }
 
 export default function memoize(...args) {
+  internalDeprecation('@memoize is deprecated and will be removed shortly. Use @memoize from lodash-decorators.\n\n  https://www.npmjs.com/package/lodash-decorators');
   return decorate(handleDescriptor, args);
 }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,4 +1,4 @@
-import { getOwnPropertyDescriptors, getOwnKeys } from './private/utils';
+import { getOwnPropertyDescriptors, getOwnKeys, internalDeprecation } from './private/utils';
 
 const { defineProperty, getPrototypeOf } = Object;
 
@@ -49,6 +49,8 @@ function handleClass(target, mixins) {
 }
 
 export default function mixin(...mixins) {
+  internalDeprecation('@mixin is deprecated and will be removed shortly. Use @mixin from lodash-decorators.\n\n  https://www.npmjs.com/package/lodash-decorators');
+
   if (typeof mixins[0] === 'function') {
     return handleClass(mixins[0], []);
   } else {

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -92,3 +92,29 @@ export function createDefaultSetter(key) {
     return newValue;
   };
 }
+
+export function bind(fn, context) {
+  if (fn.bind) {
+    return fn.bind(context);
+  } else {
+    return function __autobind__() {
+      return fn.apply(context, arguments);
+    };
+  }
+}
+
+export const warn = (() => {
+  if (typeof console !== 'object' || !console || typeof console.warn !== 'function') {
+    return () => {};
+  } else {
+    return bind(console.warn, console);
+  }
+})();
+
+const seenDeprecations = {};
+export function internalDeprecation(msg) {
+  if (seenDeprecations[msg] !== true) {
+    seenDeprecations[msg] = true;
+    warn('DEPRECATION: ' + msg);
+  }
+}

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,18 +1,18 @@
-import { decorate, metaFor } from './private/utils';
+import { decorate, metaFor, warn, bind } from './private/utils';
 
 const oc = console;
 
 // Exported for mocking in tests
 export const defaultConsole = {
-  profile: console.profile ? console.profile.bind(console) : () => {},
-  profileEnd: console.profileEnd ? console.profileEnd.bind(console) : () => {},
-  warn: console.warn.bind(console)
+  profile: console.profile ? bind(console.profile, console) : () => {},
+  profileEnd: console.profileEnd ? bind(console.profileEnd, console) : () => {},
+  warn
 };
 
 function handleDescriptor(target, key, descriptor, [prefix = null, onceThrottleOrFunction = false, console = defaultConsole]) {
   if (!profile.__enabled) {
     if (!profile.__warned) {
-      console.warn('Console.profile is not supported. All @profile decorators are disabled.');
+      console.warn('console.profile is not supported. All @profile decorators are disabled.');
       profile.__warned = true;
     }
     return descriptor;

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -1,4 +1,4 @@
-import { decorate, metaFor } from './private/utils';
+import { decorate, metaFor, internalDeprecation } from './private/utils';
 
 const DEFAULT_TIMEOUT = 300;
 
@@ -58,5 +58,6 @@ function handleDescriptor(target, key, descriptor, [wait = DEFAULT_TIMEOUT, opti
 }
 
 export default function throttle(...args) {
+  internalDeprecation('@throttle is deprecated and will be removed shortly. Use @throttle from lodash-decorators.\n\n  https://www.npmjs.com/package/lodash-decorators');
   return decorate(handleDescriptor, args);
 }

--- a/test/unit/deprecate.spec.js
+++ b/test/unit/deprecate.spec.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import deprecate from '../../lib/deprecate';
+import * as utils from '../../lib/private/utils';
 
 class Foo {
   @deprecate
@@ -24,23 +25,23 @@ class Foo {
 
 describe('@deprecate', function () {
   beforeEach(function () {
-    sinon.spy(console, 'warn');
+    sinon.spy(utils, 'warn');
   });
 
   afterEach(function () {
-    console.warn.restore();
+    utils.warn.restore();
   });
 
   it('console.warn() is called with default warning when the deprecated function is used', function () {
     const foo = new Foo();
     
     foo.first().should.equal('hello world');
-    console.warn.should.have.been.calledOnce;
-    console.warn.should.have.been.calledWith('DEPRECATION Foo#first: This function will be removed in future versions.');
+    utils.warn.should.have.been.calledOnce;
+    utils.warn.should.have.been.calledWith('DEPRECATION Foo#first: This function will be removed in future versions.');
 
     foo.second().should.equal('hello world');
-    console.warn.should.have.been.calledTwice;
-    console.warn.should.have.been.calledWith('DEPRECATION Foo#first: This function will be removed in future versions.');
+    utils.warn.should.have.been.calledTwice;
+    utils.warn.should.have.been.calledWith('DEPRECATION Foo#first: This function will be removed in future versions.');
   });
 
   it('console.warn() is called with the custom message, when provided', function () {
@@ -48,15 +49,15 @@ describe('@deprecate', function () {
     const foo = new Foo();
     
     foo.third().should.equal('hello galaxy');
-    console.warn.should.have.been.calledOnce;
-    console.warn.should.have.been.calledWith('asdf');
+    utils.warn.should.have.been.calledOnce;
+    utils.warn.should.have.been.calledWith('asdf');
   });
 
   it('console.warn() is called with the URL, when provided', function () {
     const foo = new Foo();
     
     foo.forth().should.equal('hello universe');
-    console.warn.should.have.been.calledOnce;
-    console.warn.should.have.been.calledWith('DEPRECATION Foo#forth: fdsa\n\n    See http://example.com/ for more details.\n\n');
+    utils.warn.should.have.been.calledOnce;
+    utils.warn.should.have.been.calledWith('DEPRECATION Foo#forth: fdsa\n\n    See http://example.com/ for more details.\n\n');
   });
 });


### PR DESCRIPTION
To be deprecated in favor of lodash-decorators:

* debounce
* throttle
* mixin
* memoize (was previous deprecated and is not documented)

> ## Need lodash utilities as decorators?
> 
> core-decorators aims to provide decorators that are fundamental to JavaScript itself--mostly things you could do with normal `Object.defineProperty` but not as easily when using ES2015 classes. Things like debouncing, throttling, and other more opinionated decorators are being phased out in favor of [lodash-decorators](https://www.npmjs.com/package/lodash-decorators) which wraps applicable lodash utilities as decorators. We don't want to duplicate the effort of lodash, which has years and years of robust testing and bugfixes.