### PR TITLE
TypeScript beginnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /node_modules/
 /built/
 .vscode
-
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /lib/
 /es/
 /node_modules/
-/core-decorators.js
+/built/
+.vscode
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /es/
 /node_modules/
 /built/
-.vscode
 *.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible Node.js debug attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--compilers", "js:babel-core/register",
+                "--require", "babel-polyfill",
+                "${workspaceRoot}/test/**/*.spec.js",
+                "--debug"
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "tsc",
+    "isShellCommand": true,
+    "args": ["-w", "-p", "."],
+    "showOutput": "silent",
+    "isBackground": true,
+    "problemMatcher": "$tsc-watch"
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+// index.ts - facade for core-decorators
+// 
+
+export * from './lib/core-decorators';

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
     "build-tsc": "tsc || npm run tsc-errors-as-warnings",
-    "tsc-errors-as-warnings":  "echo \"TypeScript errors treated as warnings\"",
+    "clean": "rimraf lib es built",
+    "tsc-errors-as-warnings": "echo \"TypeScript errors treated as warnings\"",
     "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
   "repository": {
@@ -68,6 +69,7 @@
     "interop-require": "1.0.0",
     "lodash": "4.17.4",
     "mocha": "^3.2.0",
+    "rimraf": "^2.6.1",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "typescript": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "postbuild-tsc": "mv --force built/src built/lib",
     "clean": "rimraf lib es built",
     "tsc-errors-as-warnings": "echo \"TypeScript errors treated as warnings\"",
-    "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\"",
+    "pretest": "npm run build",
+    "test": "mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\"",
     "test-tsc": "rimraf built && npm run build-tsc && mocha  \"built/test/**/*.spec.js\""
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepublish": "npm run build",
     "build": "rimraf lib && babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
     "prebuild-tsc": "rimraf built",

--- a/package.json
+++ b/package.json
@@ -13,15 +13,13 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
+    "build": "rimraf lib && babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
-    "build-tsc": "tsc || npm run tsc-errors-as-warnings",
-    "postbuild-tsc": "mv --force built/src built/lib",
+    "prebuild-tsc": "rimraf built",
+    "build-tsc": "tsc --outDir lib",
     "clean": "rimraf lib es built",
     "tsc-errors-as-warnings": "echo \"TypeScript errors treated as warnings\"",
-    "pretest": "npm run build",
-    "test": "mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\"",
-    "test-tsc": "rimraf built && npm run build-tsc && mocha  \"built/test/**/*.spec.js\""
+    "test": "mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
   "repository": {
     "type": "git",
@@ -75,7 +73,7 @@
     "mocha": "^3.2.0",
     "mv": "^2.1.1",
     "rimraf": "^2.6.1",
-    "sinon": "^2.1.0",
+    "sinon": "2.1.0",
     "sinon-chai": "^2.9.0",
     "typescript": "^2.3.3"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "prebuild-tsc": "rimraf built",
     "build-tsc": "tsc --outDir lib",
     "clean": "rimraf lib es built",
-    "tsc-errors-as-warnings": "echo \"TypeScript errors treated as warnings\"",
     "test": "mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
   "repository": {
@@ -65,14 +64,12 @@
     "babel-preset-es2015": "^6.24.0",
     "camelcase": "^4.1.0",
     "chai": "^3.5.0",
-    "cpy-cli": "^1.0.1",
     "cross-env": "^5.0.0",
     "glob": "^7.1.1",
     "global-wrap": "^2.0.0",
     "interop-require": "1.0.0",
     "lodash": "4.17.4",
     "mocha": "^3.2.0",
-    "mv": "^2.1.1",
     "rimraf": "^2.6.1",
     "sinon": "2.1.0",
     "sinon-chai": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "build": "babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
     "build-tsc": "tsc || npm run tsc-errors-as-warnings",
+    "postbuild-tsc": "mv --force built/src built/lib",
     "clean": "rimraf lib es built",
     "tsc-errors-as-warnings": "echo \"TypeScript errors treated as warnings\"",
-    "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
+    "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\"",
+    "test-tsc": "rimraf built && npm run build-tsc && mocha  \"built/test/**/*.spec.js\""
   },
   "repository": {
     "type": "git",
@@ -63,12 +65,14 @@
     "babel-preset-es2015": "^6.24.0",
     "camelcase": "^4.1.0",
     "chai": "^3.5.0",
+    "cpy-cli": "^1.0.1",
     "cross-env": "^5.0.0",
     "glob": "^7.1.1",
     "global-wrap": "^2.0.0",
     "interop-require": "1.0.0",
     "lodash": "4.17.4",
     "mocha": "^3.2.0",
+    "mv": "^2.1.1",
     "rimraf": "^2.6.1",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "build": "babel --out-dir lib src && cross-env BABEL_ENV=es babel --out-dir es src",
     "build-bower": "babel-node scripts/build-bower.js",
+    "build-tsc": "tsc || npm run tsc-errors-as-warnings",
+    "tsc-errors-as-warnings":  "echo \"TypeScript errors treated as warnings\"",
     "test": "npm run build && mocha --compilers js:babel-core/register --require babel-polyfill \"test/**/*.spec.js\""
   },
   "repository": {
@@ -46,6 +48,9 @@
   },
   "homepage": "https://github.com/jayphelps/core-decorators.js",
   "devDependencies": {
+    "@types/chai": "^3.5.2",
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^6.0.73",
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-plugin-transform-class-properties": "^6.23.0",
@@ -64,6 +69,7 @@
     "lodash": "4.17.4",
     "mocha": "^3.2.0",
     "sinon": "^2.1.0",
-    "sinon-chai": "^2.9.0"
+    "sinon-chai": "^2.9.0",
+    "typescript": "^2.3.3"
   }
 }

--- a/src/override.js
+++ b/src/override.js
@@ -110,7 +110,7 @@ function getDescriptorType(descriptor) {
   return 'data';
 }
 
-function checkFunctionSignatures(parent: Function, child: Function, reporter) {
+function checkFunctionSignatures(parent, child, reporter) {
   reporter.assert(parent.length === child.length);
 }
 

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -24,7 +24,7 @@ export function decorate(handleDescriptor, entryArgs) {
     return handleDescriptor(...entryArgs, []);
   } else {
     return function () {
-      return handleDescriptor(...arguments, entryArgs);
+      return handleDescriptor(...Array.from(arguments), entryArgs);
     };
   }
 }

--- a/src/private/utils.js
+++ b/src/private/utils.js
@@ -24,7 +24,7 @@ export function decorate(handleDescriptor, entryArgs) {
     return handleDescriptor(...entryArgs, []);
   } else {
     return function () {
-      return handleDescriptor(...Array.from(arguments), entryArgs);
+      return handleDescriptor(...Array.prototype.slice.call(arguments), entryArgs);
     };
   }
 }

--- a/test/exports.spec.js
+++ b/test/exports.spec.js
@@ -1,8 +1,8 @@
-import chai from 'chai'
-import path from 'path';
-import glob from 'glob';
-import toCamelCase from 'camelcase';
-import interopRequire from 'interop-require';
+import * as chai from 'chai'
+import * as path from 'path';
+import * as glob from 'glob';
+import * as toCamelCase from 'camelcase';
+import * as interopRequire from 'interop-require';
 import * as decorators from '../';
 
 const should = chai.should();

--- a/test/exports.spec.js
+++ b/test/exports.spec.js
@@ -1,8 +1,8 @@
 import * as chai from 'chai'
 import * as path from 'path';
 import * as glob from 'glob';
-import * as toCamelCase from 'camelcase';
-import * as interopRequire from 'interop-require';
+import toCamelCase from 'camelcase';
+import interopRequire from 'interop-require';
 import * as decorators from '../';
 
 const should = chai.should();

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,6 +1,6 @@
-import chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
 
 chai.should();
 chai.use(sinonChai);

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
-import sinon from 'sinon';
-import sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
 
 chai.should();
 chai.use(sinonChai);

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
-import * as sinon from 'sinon';
-import * as sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.should();
 chai.use(sinonChai);

--- a/test/unit/extendDescriptor.js
+++ b/test/unit/extendDescriptor.js
@@ -78,15 +78,15 @@ describe('@extendDescriptor', function () {
   });
 
   it('extends property initializers', function () {
-    Object.getOwnPropertyDescriptor(Derived.prototype, 'fourth');
-      .enumerable.should.equal(false);
+    const descriptor = Object.getOwnPropertyDescriptor(Derived.prototype, 'fourth');
+    descriptor.enumerable.should.equal(false);
 
     derived.fourth.should.equal('fourth');
   });
 
   it('extends property methods', function () {
-    Object.getOwnPropertyDescriptor(Derived.prototype, 'fifth');
-      .enumerable.should.equal(true);
+    const descriptor = Object.getOwnPropertyDescriptor(Derived.prototype, 'fifth');
+    descriptor.enumerable.should.equal(true);
 
     derived.fifth().should.equal('fourth');
   });

--- a/test/unit/mixin.spec.js
+++ b/test/unit/mixin.spec.js
@@ -19,7 +19,7 @@ const OverrideMixin = {
 };
 
 function applyMixins(...mixins) {
-  return @mixin(...mixins)
+  @mixin(...mixins)
     class Foo {
       getStuff3() {
         return 'stuff3';
@@ -28,14 +28,15 @@ function applyMixins(...mixins) {
       getStuff4() {
         return 'stuff4';
       }
-    };
+    }
+  return Foo;
 }
 
 describe('@mixin', function () {
   it('throws if you do not provide at least one mixin', function () {
     (function () {
-      var foo = @mixin class Bad {};
-      console.error(foo);
+      @mixin class Bad {};
+      console.error(Bad);
     }).should.throw('@mixin() class Bad requires at least one mixin as an argument');
 
     (function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["scripts", "lib/**", "es", "node_modules", "built" ],
+  "exclude": ["scripts", "lib", "es", "node_modules", "built" ],
   "compilerOptions": {
     "outDir": "built",
     "target": "es5",
@@ -12,6 +12,10 @@
       "dom",
       "es2015","es2015.core", "es2015.collection"
     ],
+    "baseUrl": ".",
+    "paths": {
+      "lib/*": ["src/*"]
+    },
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "exclude": ["scripts", "lib/**", "es", "node_modules", "built" ],
+  "compilerOptions": {
+    "outDir": "built",
+    "target": "es5",
+    "module":"commonjs",
+    "sourceMap": true,
+    "allowJs": true,
+    "checkJs": true,
+    "allowUnreachableCode": true,
+    "lib": [
+      "dom",
+      "es2015","es2015.core", "es2015.collection"
+    ],
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "compileOnSave": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["scripts", "lib", "es", "node_modules", "built" ],
+  "exclude": ["scripts", "lib/**", "es", "node_modules", "built" ],
   "compilerOptions": {
     "outDir": "built",
     "target": "es5",
@@ -16,6 +16,9 @@
     "paths": {
       "lib/*": ["src/*"]
     },
+    "rootDirs": [
+      "src", "lib"
+    ],
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module":"commonjs",
     "sourceMap": true,
     "allowJs": true,
-    "checkJs": true,
+    "checkJs": false,
     "allowUnreachableCode": true,
     "lib": [
       "dom",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,9 @@
     "sourceMap": true,
     "allowJs": true,
     "checkJs": false,
-    "allowUnreachableCode": false,
+    "allowUnreachableCode": true,
     "lib": [
+      "es5",
       "dom",
       "es2015","es2015.core", "es2015.collection"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "module":"commonjs",
     "sourceMap": true,
     "allowJs": true,
-    "checkJs": true,
+    "checkJs": false,
     "allowUnreachableCode": false,
     "lib": [
       "dom",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,8 @@
     "module":"commonjs",
     "sourceMap": true,
     "allowJs": true,
-    "checkJs": false,
-    "allowUnreachableCode": true,
+    "checkJs": true,
+    "allowUnreachableCode": false,
     "lib": [
       "dom",
       "es2015","es2015.core", "es2015.collection"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src"],
   "exclude": ["scripts", "lib/**", "es", "node_modules", "built" ],
   "compilerOptions": {
     "outDir": "built",


### PR DESCRIPTION
Add support for building project with TypeScript

This saves the gems from my experimental branch, without adopting some of the mistakes.   It _enables_ you to either type `tsc` or `npm run build-tsc` to build all the source files from this project into a new `built` directory.   This is intended to facilitate comparison with the babel generated code, and add some error checking.

Note that the error checking is currently fairly minimal, as the its using --allowJs, but **not** --checkJs.  I've also included in this PR code fixes for some of the error reported by tsc the command generally results in a clean build.   