### PR TITLE
Added typings from @types, typings should now ship with the package.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,13 +16,6 @@ export interface DeprecateOption {
   url: string;
 }
 
-export interface ThrottleOptions {
-  /** allows to trigger function on the leading. */
-  leading?: boolean;
-  /** allows to trigger function on the trailing edge of the wait interval. */
-  trailing?: boolean;
-}
-
 /**
  * Forces invocations of this function to always have this refer to the class instance,
  * even if the function is passed around or would otherwise lose its this context. e.g. var fn = context.method;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,48 +1,26 @@
-// Type definitions for core-decorators.js 0.10
+// Type definitions for core-decorators.js 0.19
 // Project: https://github.com/jayphelps/core-decorators.js
 // Definitions by: Qubo <https://github.com/tkqubo>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 2.1
-
-export interface ClassDecorator {
-    <TFunction extends Function>(target: TFunction): TFunction | void;
-}
-
-export interface ParameterDecorator {
-    (target: object, propertyKey: string | symbol, parameterIndex: number): void;
-}
-
-export interface PropertyDecorator {
-    (target: object, propertyKey: string | symbol): void;
-}
-
-export interface MethodDecorator {
-    <T>(target: object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;
-}
+//                 dtweedle <https://github.com/dtweedle>
+// TypeScript Version: 2.4.1
 
 export interface PropertyOrMethodDecorator extends MethodDecorator, PropertyDecorator {
-    (target: object, propertyKey: string | symbol): void;
+  (target: object, propertyKey: string | symbol): void;
 }
 
 export interface Deprecate extends MethodDecorator {
-    (message?: string, option?: DeprecateOption): MethodDecorator;
+  (message?: string, option?: DeprecateOption): MethodDecorator;
 }
 
 export interface DeprecateOption {
-    url: string;
+  url: string;
 }
 
 export interface ThrottleOptions {
-    /** allows to trigger function on the leading. */
-    leading?: boolean;
-    /** allows to trigger function on the trailing edge of the wait interval. */
-    trailing?: boolean;
-}
-
-export interface Console {
-    log(message?: any, ...optionalParams: any[]): void;
-    time(timerName?: string): void;
-    timeEnd(timerName?: string): void;
+  /** allows to trigger function on the leading. */
+  leading?: boolean;
+  /** allows to trigger function on the trailing edge of the wait interval. */
+  trailing?: boolean;
 }
 
 /**
@@ -66,14 +44,6 @@ export const deprecate: Deprecate;
  * Calls console.warn() with a deprecation message. Provide a custom message to override the default one. You can also provide an options hash with a url, for further reading.
  */
 export const deprecated: Deprecate;
-/**
- * Creates a new debounced function which will be invoked after wait milliseconds since the time it was invoked. Default timeout is 300 ms.
- */
-export function debounce(wait: number): MethodDecorator;
-/**
- * Creates a new throttled function which will be invoked in every wait milliseconds. Default timeout is 300 ms.
- */
-export function throttle(wait: number, options?: ThrottleOptions): MethodDecorator;
 /**
  * Suppresses any JavaScript console.warn() call while the decorated function is called. (i.e. on the stack)
  */
@@ -100,16 +70,6 @@ export function decorate(func: Function, ...args: any[]): MethodDecorator;
  * Useful to prevent excess allocations that might otherwise not be used, but be careful not to over-optimize things.
  */
 export const lazyInitialize: PropertyDecorator;
-/**
- * Mixes in all property descriptors from the provided Plain Old JavaScript Objects (aka POJOs) as arguments.
- * Mixins are applied in the order they are passed, but do not override descriptors already on the class, including those inherited traditionally.
- */
-export function mixin(...mixins: any[]): ClassDecorator;
-/**
- * Mixes in all property descriptors from the provided Plain Old JavaScript Objects (aka POJOs) as arguments.
- * Mixins are applied in the order they are passed, but do not override descriptors already on the class, including those inherited traditionally.
- */
-export function mixins(...mixins: any[]): ClassDecorator;
 /**
  * Uses console.time and console.timeEnd to provide function timings with a unique label whose default prefix is ClassName.method. Supply a first argument to override the prefix:
  */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,116 @@
+// Type definitions for core-decorators.js 0.10
+// Project: https://github.com/jayphelps/core-decorators.js
+// Definitions by: Qubo <https://github.com/tkqubo>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.1
+
+export interface ClassDecorator {
+    <TFunction extends Function>(target: TFunction): TFunction | void;
+}
+
+export interface ParameterDecorator {
+    (target: object, propertyKey: string | symbol, parameterIndex: number): void;
+}
+
+export interface PropertyDecorator {
+    (target: object, propertyKey: string | symbol): void;
+}
+
+export interface MethodDecorator {
+    <T>(target: object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> | void;
+}
+
+export interface PropertyOrMethodDecorator extends MethodDecorator, PropertyDecorator {
+    (target: object, propertyKey: string | symbol): void;
+}
+
+export interface Deprecate extends MethodDecorator {
+    (message?: string, option?: DeprecateOption): MethodDecorator;
+}
+
+export interface DeprecateOption {
+    url: string;
+}
+
+export interface ThrottleOptions {
+    /** allows to trigger function on the leading. */
+    leading?: boolean;
+    /** allows to trigger function on the trailing edge of the wait interval. */
+    trailing?: boolean;
+}
+
+export interface Console {
+    log(message?: any, ...optionalParams: any[]): void;
+    time(timerName?: string): void;
+    timeEnd(timerName?: string): void;
+}
+
+/**
+ * Forces invocations of this function to always have this refer to the class instance,
+ * even if the function is passed around or would otherwise lose its this context. e.g. var fn = context.method;
+ */
+export const autobind: Function;
+/**
+ * Marks a property or method as not being writable.
+ */
+export const readonly: PropertyOrMethodDecorator;
+/**
+ * Checks that the marked method indeed overrides a function with the same signature somewhere on the prototype chain.
+ */
+export const override: MethodDecorator;
+/**
+ * Calls console.warn() with a deprecation message. Provide a custom message to override the default one. You can also provide an options hash with a url, for further reading.
+ */
+export const deprecate: Deprecate;
+/**
+ * Calls console.warn() with a deprecation message. Provide a custom message to override the default one. You can also provide an options hash with a url, for further reading.
+ */
+export const deprecated: Deprecate;
+/**
+ * Creates a new debounced function which will be invoked after wait milliseconds since the time it was invoked. Default timeout is 300 ms.
+ */
+export function debounce(wait: number): MethodDecorator;
+/**
+ * Creates a new throttled function which will be invoked in every wait milliseconds. Default timeout is 300 ms.
+ */
+export function throttle(wait: number, options?: ThrottleOptions): MethodDecorator;
+/**
+ * Suppresses any JavaScript console.warn() call while the decorated function is called. (i.e. on the stack)
+ */
+export const suppressWarnings: MethodDecorator;
+/**
+ * Marks a property or method as not being enumerable.
+ */
+export const nonenumerable: PropertyOrMethodDecorator;
+/**
+ * Marks a property or method as not being writable.
+ */
+export const nonconfigurable: PropertyOrMethodDecorator;
+/**
+ * Initial implementation included, likely slow. WIP.
+ */
+export const memoize: MethodDecorator;
+/**
+ * Immediately applies the provided function and arguments to the method, allowing you to wrap methods with arbitrary helpers like those provided by lodash.
+ * The first argument is the function to apply, all further arguments will be passed to that decorating function.
+ */
+export function decorate(func: Function, ...args: any[]): MethodDecorator;
+/**
+ * Prevents a property initializer from running until the decorated property is actually looked up.
+ * Useful to prevent excess allocations that might otherwise not be used, but be careful not to over-optimize things.
+ */
+export const lazyInitialize: PropertyDecorator;
+/**
+ * Mixes in all property descriptors from the provided Plain Old JavaScript Objects (aka POJOs) as arguments.
+ * Mixins are applied in the order they are passed, but do not override descriptors already on the class, including those inherited traditionally.
+ */
+export function mixin(...mixins: any[]): ClassDecorator;
+/**
+ * Mixes in all property descriptors from the provided Plain Old JavaScript Objects (aka POJOs) as arguments.
+ * Mixins are applied in the order they are passed, but do not override descriptors already on the class, including those inherited traditionally.
+ */
+export function mixins(...mixins: any[]): ClassDecorator;
+/**
+ * Uses console.time and console.timeEnd to provide function timings with a unique label whose default prefix is ClassName.method. Supply a first argument to override the prefix:
+ */
+export function time(label: string, console?: Console): MethodDecorator;

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "lib/core-decorators.js",
   "module": "es/core-decorators.js",
   "jsnext:main": "es/core-decorators.js",
+  "typings": "./index.d.ts",
   "files": [
     "es",
     "lib",
     "src",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "index.d.ts"
   ],
   "scripts": {
     "prepublish": "npm run build",


### PR DESCRIPTION
Closes #128 

The typings (@types) project has grown to be a pain and splits away concerns for keeping community typings up to date separate from the packages themselves. 

PR is to merge typings into the actual project where they can be maintained. 

They might be slightly out of date but it will be easier to keep track of what needs fixing here.